### PR TITLE
Cowboy needs cowlib to be started.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 	@test -d deps || rebar get-deps	
 	rebar compile
-	erl -pa './deps/cowboy/ebin' -pa './deps/ranch/ebin' -pa './ebin' -s ws start chandler 
+	erl -pa './deps/cowlib/ebin' -pa './deps/cowboy/ebin' -pa './deps/ranch/ebin' -pa './ebin' -s ws start chandler 
 
 

--- a/src/ws.erl
+++ b/src/ws.erl
@@ -45,6 +45,7 @@ read_config(File) ->
 start_link(Conf) ->
     ok = application:start(crypto),
     ok = application:start(ranch),  
+    ok = application:start(cowlib),
     ok = application:start(cowboy),
     ok = web_server_start(Conf),
     receive


### PR DESCRIPTION
As a result of tracking cowboy master this change is needed to start chandler.

You also need to copy website to ~/published in order for the application to be
able to serve anything.
